### PR TITLE
fix: harden project-ready scheduler and checkout overview validation

### DIFF
--- a/.github/workflows/project-ready-orchestrator.yml
+++ b/.github/workflows/project-ready-orchestrator.yml
@@ -1,9 +1,10 @@
 name: Project Ready Orchestrator
 
 on:
-  schedule:
-    - cron: '*/10 * * * *'
   workflow_dispatch:
+  repository_dispatch:
+    types:
+      - project-ready-tick
 
 permissions:
   contents: write
@@ -18,6 +19,7 @@ jobs:
   ready-to-pr:
     name: Ready -> Branch/Test/PR -> In review
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
       BASE_URL: ${{ vars.BASE_URL }}
@@ -33,6 +35,12 @@ jobs:
       WORK_CMD: ${{ vars.PROJECT_READY_WORK_CMD }}
 
     steps:
+      - name: Print trigger context
+        run: |
+          echo "event=${GITHUB_EVENT_NAME}"
+          echo "ref=${GITHUB_REF}"
+          date -u '+%Y-%m-%d %H:%M:%S UTC'
+
       - name: Validate automation token
         id: token
         run: |

--- a/.github/workflows/project-ready-scheduler.yml
+++ b/.github/workflows/project-ready-scheduler.yml
@@ -1,0 +1,32 @@
+name: Project Ready Scheduler
+
+on:
+  schedule:
+    - cron: '3-59/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: project-ready-scheduler
+  cancel-in-progress: true
+
+jobs:
+  tick:
+    name: Dispatch Orchestrator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Project Ready Orchestrator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflowId = 'project-ready-orchestrator.yml';
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowId,
+              ref: 'main',
+            });
+            core.info(`Dispatched ${workflowId} on main at ${new Date().toISOString()}`);

--- a/llms.txt
+++ b/llms.txt
@@ -125,7 +125,8 @@ If using GitHub Project automation (`BrunoZanotta / project #3`), execute:
 
 CI workflows:
 - `.github/workflows/playwright.yml`
-- `.github/workflows/project-ready-orchestrator.yml` (scheduler for card-driven automation)
+- `.github/workflows/project-ready-scheduler.yml` (cron ticker every 5 minutes, off top-of-hour)
+- `.github/workflows/project-ready-orchestrator.yml` (executor for card-driven branch/test/gate/PR flow)
 
 Local policy script:
 - `scripts/ci/governance-gate.sh`
@@ -137,6 +138,9 @@ Delivery scripts:
 - `scripts/git/project-move-item.sh`
 
 ## Scheduler Runtime Config
+
+Cadence:
+- `project-ready-scheduler.yml` ticks at minutes `3,8,13,18,23,28,33,38,43,48,53,58` (UTC).
 
 Required:
 - Secret `GH_PROJECT_TOKEN` (repo + project scopes)

--- a/pages/CheckoutPage.ts
+++ b/pages/CheckoutPage.ts
@@ -141,8 +141,14 @@ export class CheckoutPage {
 
   async assertProductInOverviewByKey(productKey: StoreProductKey) {
     const product = STORE_PRODUCTS[productKey];
-    await expect(this.page.getByText(product.name)).toBeVisible();
-    await expect(this.page.locator('.inventory_item_price', { hasText: product.price })).toBeVisible();
+    const overviewItem = this.page.locator('.cart_item', {
+      has: this.page.locator('.inventory_item_name', { hasText: product.name }),
+    });
+
+    await expect(overviewItem).toHaveCount(1);
+    await expect(overviewItem.locator('.inventory_item_name')).toHaveText(product.name);
+    await expect(overviewItem.locator('.inventory_item_desc')).toContainText(product.descriptionSnippet);
+    await expect(overviewItem.locator('.inventory_item_price')).toHaveText(product.price);
   }
 
   private parseMoneyValue(text: string): number {

--- a/tests/checkout/check-001-checkout-information.spec.ts
+++ b/tests/checkout/check-001-checkout-information.spec.ts
@@ -18,4 +18,28 @@ test.describe('Checkout Process Tests', { tag: '@checkout' }, () => {
     await checkoutPage.assertDefaultShippingMethod();
     await checkoutPage.assertProductInOverviewByKey('backpack');
   });
+
+  test('Checkout Overview Supports Duplicate Product Prices', { tag: '@regression' }, async ({
+    authenticatedPage: _authenticatedPage,
+    inventoryPage,
+    cartPage,
+    checkoutPage,
+  }) => {
+    await inventoryPage.addProductToCartByKey('boltTShirt');
+    await inventoryPage.addProductToCartByKey('tShirtRed');
+
+    await inventoryPage.goToCart();
+    await cartPage.assertOnCartPage();
+    await cartPage.proceedToCheckout();
+
+    await checkoutPage.assertOnCheckoutInfoPage();
+    await checkoutPage.fillCheckoutInformationFromProfile('valid');
+    await checkoutPage.clickContinue();
+
+    await checkoutPage.assertOnCheckoutOverviewPage();
+    await checkoutPage.assertProductInOverviewByKey('boltTShirt');
+    await checkoutPage.assertProductInOverviewByKey('tShirtRed');
+    await checkoutPage.assertSubtotalEqualsProductSum(['boltTShirt', 'tShirtRed']);
+    await checkoutPage.assertTotalEqualsSubtotalPlusTax();
+  });
 });


### PR DESCRIPTION
## Summary\n- split scheduler and executor workflows for the project-ready automation\n- added dedicated scheduler workflow with off-peak cron and dispatch trigger\n- hardened checkout overview product assertion to avoid strict-mode ambiguity on duplicate prices\n- added checkout regression test covering duplicate-price products\n- updated llms.txt workflow contract to match the new scheduler/executor architecture\n\n## Validation\n- npx playwright test --list --project=chromium\n- npx playwright test tests/checkout/check-001-checkout-information.spec.ts --project=chromium\n- ./scripts/ci/governance-gate.sh governance-gate-report.md\n