### PR TITLE
fix(automation): restore reliable scheduler for Ready card processing

### DIFF
--- a/.github/workflows/project-ready-orchestrator.yml
+++ b/.github/workflows/project-ready-orchestrator.yml
@@ -1,8 +1,6 @@
 name: Project Ready Orchestrator
 
 on:
-  schedule:
-    - cron: '3-59/5 * * * *'
   workflow_dispatch:
   repository_dispatch:
     types:

--- a/.github/workflows/project-ready-scheduler.yml
+++ b/.github/workflows/project-ready-scheduler.yml
@@ -1,0 +1,32 @@
+name: Project Ready Scheduler
+
+on:
+  schedule:
+    - cron: '3-59/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: project-ready-scheduler
+  cancel-in-progress: true
+
+jobs:
+  tick:
+    name: Dispatch Orchestrator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Project Ready Orchestrator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflowId = 'project-ready-orchestrator.yml';
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowId,
+              ref: 'main',
+            });
+            core.info(`Dispatched ${workflowId} on main at ${new Date().toISOString()}`);

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ autonomous-testing-ui/
 │   │       └── github-project-ready-pr-orchestrator.agent.md
 │   ├── workflows/
 │   │   ├── playwright.yml                  # CI/CD em stages
-│   │   └── project-ready-orchestrator.yml # Cron: Ready -> In progress -> In review
+│   │   ├── project-ready-scheduler.yml    # Cron: dispara orquestrador a cada 5 min
+│   │   └── project-ready-orchestrator.yml # Executor: Ready -> In progress -> In review
 ├── scripts/
 │   ├── ci/
 │   │   └── governance-gate.mjs
@@ -188,7 +189,8 @@ Use este agent para operacao automatizada via GitHub Project:
 - mover card para `In Review` apos criacao do PR
 
 Agendamento automatico:
-- `.github/workflows/project-ready-orchestrator.yml` roda por cron a cada 5 minutos (alem de permitir `workflow_dispatch`).
+- `.github/workflows/project-ready-scheduler.yml` roda por cron a cada 5 minutos e dispara o orquestrador.
+- `.github/workflows/project-ready-orchestrator.yml` executa o fluxo e tambem permite `workflow_dispatch`.
 - Sem interação no terminal: basta o card estar em `Ready` para entrar no próximo ciclo.
 - Labels de tipo (`bug` / `new test`) são recomendadas; sem label o fluxo infere o tipo pelo título/corpo e usa fallback `newTest`.
 

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -3,11 +3,12 @@
 Este projeto ja possui automacao completa em GitHub Actions para:
 - CI de testes Playwright por estagios
 - Orquestracao de cards `Ready -> In progress -> In review`
-- Agendamento automatico de processamento de cards (cron no orchestrator)
+- Agendamento automatico de processamento de cards (cron no scheduler)
 - Execucao sem necessidade de interagir no terminal
 
 ## Workflows existentes
 - `.github/workflows/playwright.yml`
+- `.github/workflows/project-ready-scheduler.yml`
 - `.github/workflows/project-ready-orchestrator.yml`
 
 ## 1) Pre-requisitos
@@ -58,6 +59,11 @@ node ./scripts/git/verify-actions-setup.mjs --json
 ```
 
 ## 5) Testar execucao manual (opcional)
+Rodar scheduler:
+```bash
+gh workflow run project-ready-scheduler.yml --repo BrunoZanotta/autonomous-testing-ui
+```
+
 Rodar orquestrador:
 ```bash
 gh workflow run project-ready-orchestrator.yml --repo BrunoZanotta/autonomous-testing-ui

--- a/llms.txt
+++ b/llms.txt
@@ -125,7 +125,8 @@ If using GitHub Project automation (`BrunoZanotta / project #3`), execute:
 
 CI workflows:
 - `.github/workflows/playwright.yml`
-- `.github/workflows/project-ready-orchestrator.yml` (executor card-driven with built-in cron every 5 minutes)
+- `.github/workflows/project-ready-scheduler.yml` (cron ticker every 5 minutes, off top-of-hour)
+- `.github/workflows/project-ready-orchestrator.yml` (executor for card-driven branch/test/gate/PR flow)
 
 Local policy script:
 - `scripts/ci/governance-gate.mjs`
@@ -136,10 +137,10 @@ Delivery scripts:
 - `scripts/git/project-ready-to-pr.mjs`
 - `scripts/git/project-move-item.mjs`
 
-## Orchestrator Runtime Config
+## Scheduler Runtime Config
 
 Cadence:
-- `project-ready-orchestrator.yml` runs at minutes `3,8,13,18,23,28,33,38,43,48,53,58` (UTC) and also supports `workflow_dispatch`.
+- `project-ready-scheduler.yml` ticks at minutes `3,8,13,18,23,28,33,38,43,48,53,58` (UTC).
 
 Required:
 - Secret `GH_PROJECT_TOKEN` (repo + project scopes)

--- a/scripts/git/verify-actions-setup.mjs
+++ b/scripts/git/verify-actions-setup.mjs
@@ -20,6 +20,7 @@ const REQUIRED_VARIABLES = [
 const REQUIRED_WORKFLOWS = [
   '.github/workflows/playwright.yml',
   '.github/workflows/project-ready-orchestrator.yml',
+  '.github/workflows/project-ready-scheduler.yml',
 ];
 
 function parseRepoFromOrigin() {


### PR DESCRIPTION
## Problem
`Project Ready Orchestrator` with inline `schedule` was not receiving `event=schedule` runs in practice, so Ready cards were not processed fully automatically.

## Root-Cause Evidence
- workflow stayed active but recent run history showed only `workflow_dispatch` events
- Ready cards remained in `Ready` without periodic pickup

## Fix Applied
- restore dedicated scheduler workflow: `.github/workflows/project-ready-scheduler.yml`
- keep orchestrator as execution workflow (`workflow_dispatch` + `repository_dispatch`)
- scheduler dispatches orchestrator every 5 minutes (`3-59/5`)
- align docs and verification script

## Why This Is More Reliable
This pattern had proven run history in this repository and decouples cron triggering from the heavy executor workflow.

## Validation
- `npm run actions:verify` => `Status: OK`
- card #11 remains in `Ready` and is now eligible for automatic pickup by scheduler ticks
