### PR TITLE
fix: harden Ready automation command fallback

### DIFF
--- a/.github/workflows/project-ready-orchestrator.yml
+++ b/.github/workflows/project-ready-orchestrator.yml
@@ -32,7 +32,7 @@ jobs:
       READY_STATUS: Ready
       IN_PROGRESS_STATUS: In progress
       IN_REVIEW_STATUS: In review
-      WORK_CMD: ${{ vars.PROJECT_READY_WORK_CMD }}
+      WORK_CMD: ${{ vars.PROJECT_READY_WORK_CMD || 'node ./scripts/git/project-ready-work.mjs' }}
 
     steps:
       - name: Print trigger context

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -27,17 +27,21 @@ gh secret set GH_PROJECT_TOKEN --repo BrunoZanotta/autonomous-testing-ui
 # repita para os outros secrets
 ```
 
-## 3) Variables obrigatorias
+## 3) Variables obrigatorias e opcionais
 - `BASE_URL`
 - `APP_USER_STANDARD_USERNAME`
 - `APP_USER_LOCKED_USERNAME`
 - `APP_USER_INVALID_USERNAME`
+
+Variavel opcional:
 - `PROJECT_READY_WORK_CMD`
 
 Valor recomendado para `PROJECT_READY_WORK_CMD`:
 ```bash
 node ./scripts/git/project-ready-work.mjs
 ```
+
+Nao use valor `.sh` (ex.: `bash ./scripts/git/project-ready-work.sh`), pois e legado.
 
 Exemplo:
 ```bash


### PR DESCRIPTION
## Context
Ready automation was failing during `Run Ready to PR flow` because `PROJECT_READY_WORK_CMD` still pointed to the removed `.sh` script.

## Changes
- add default `WORK_CMD` fallback to `.mjs` in orchestrator workflow
- fix deprecated `.sh` detection regex in `project-ready-to-pr.mjs`
- rollback card to `Ready` and comment issue when flow fails after moving to `In progress`
- improve setup verification to detect deprecated `PROJECT_READY_WORK_CMD` values
- update setup docs with optional variable and deprecated value note

## Validation
- `node --check scripts/git/project-ready-to-pr.mjs`
- `node --check scripts/git/verify-actions-setup.mjs`
- `npm run -s actions:verify`
