### PR TITLE
fix: handle generic ready cards without failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Agendamento automatico:
 - `.github/workflows/project-ready-orchestrator.yml` executa o fluxo e tambem permite `workflow_dispatch`.
 - Sem interação no terminal: basta o card estar em `Ready` para entrar no próximo ciclo.
 - Labels de tipo (`bug` / `new test`) são recomendadas; sem label o fluxo infere o tipo pelo título/corpo e usa fallback `newTest`.
+- Se o card for genérico (sem pista de inventory/cart), o gerador aplica fallback para um cenário padrão de carrinho com dois produtos.
 
 Scripts de apoio:
 ```bash

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -77,6 +77,7 @@ gh workflow run project-ready-orchestrator.yml --repo BrunoZanotta/autonomous-te
 - Card precisa estar em `Ready`
 - Label de tipo recomendada: `bug` ou `new test`
 - Sem label de tipo, o fluxo infere o tipo pelo titulo/corpo e usa fallback `newTest`
+- Se o texto do card for generico (sem pista de inventory/cart), o gerador cria um teste padrao de carrinho com dois produtos
 - Priorizacao automatica: `bugfix` primeiro, depois `P0`, `P1`, `P2`
 
 Se nao houver card elegivel, o workflow encerra sem erro.

--- a/scripts/git/project-ready-work.mjs
+++ b/scripts/git/project-ready-work.mjs
@@ -7,6 +7,7 @@ import { run } from '../lib/cli.mjs';
 const cardTitle = process.env.PROJECT_CARD_TITLE ?? '';
 const cardBody = process.env.PROJECT_CARD_BODY ?? '';
 const cardText = `${cardTitle} ${cardBody}`.trim();
+const cardWorkType = process.env.PROJECT_CARD_WORK_TYPE ?? 'newTest';
 const dryRun = process.env.DRY_RUN === '1';
 const runTargetedTests = process.env.RUN_TARGETED_TESTS !== '0';
 const issueNumberRaw = process.env.PROJECT_CARD_ISSUE_NUMBER ?? '0';
@@ -175,7 +176,11 @@ try {
       createdTestFile = generateInventoryTestByName(productName);
     }
   } else {
-    throw new Error(`error: unsupported card type for automated generator. title: ${cardTitle}`);
+    // Fallback keeps the automation moving even when card text is generic.
+    process.stdout.write(
+      `No explicit cart/inventory intent found for '${cardTitle}'. Using default cart two-products scenario (work_type=${cardWorkType}).\n`,
+    );
+    createdTestFile = generateCartTwoProductsTest(products);
   }
 
   if (!dryRun && runTargetedTests) {


### PR DESCRIPTION
## Context
Even after fixing `.sh` references, generic Ready cards (without inventory/cart hints) caused `project-ready-work.mjs` to fail and the item to bounce back to Ready.

## Changes
- add generator fallback for generic card text to create a default cart two-products scenario
- document this fallback in README and setup guide

## Validation
- `node --check scripts/git/project-ready-work.mjs`
- `PROJECT_CARD_TITLE='Validar scheduler automaticamente' PROJECT_CARD_BODY='card generico sem pistas' PROJECT_CARD_WORK_TYPE='newTest' DRY_RUN=1 RUN_TARGETED_TESTS=0 node ./scripts/git/project-ready-work.mjs`
