### PR TITLE
fix: make ready scheduler resilient beyond cron

### DIFF
--- a/.github/workflows/project-ready-scheduler.yml
+++ b/.github/workflows/project-ready-scheduler.yml
@@ -4,6 +4,14 @@ on:
   schedule:
     - cron: '3-59/5 * * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows:
+      - Project Ready Orchestrator
+    types:
+      - completed
 
 permissions:
   actions: write
@@ -18,6 +26,16 @@ jobs:
     name: Dispatch Orchestrator
     runs-on: ubuntu-latest
     steps:
+      - name: Print trigger context
+        run: |
+          echo "event=${GITHUB_EVENT_NAME}"
+          echo "ref=${GITHUB_REF}"
+          date -u '+%Y-%m-%d %H:%M:%S UTC'
+
+      - name: Cooldown before next cycle
+        if: github.event_name == 'workflow_run'
+        run: sleep 300
+
       - name: Dispatch Project Ready Orchestrator
         uses: actions/github-script@v7
         with:

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ Use este agent para operacao automatizada via GitHub Project:
 - mover card para `In Review` apos criacao do PR
 
 Agendamento automatico:
-- `.github/workflows/project-ready-scheduler.yml` roda por cron a cada 5 minutos e dispara o orquestrador.
+- `.github/workflows/project-ready-scheduler.yml` roda em loop por `workflow_run` do orquestrador (cooldown de 5 min), com `cron` como backup.
+- `push` em `main` tambem pode bootstrapar o scheduler automaticamente.
 - `.github/workflows/project-ready-orchestrator.yml` executa o fluxo e tambem permite `workflow_dispatch`.
 - Sem interação no terminal: basta o card estar em `Ready` para entrar no próximo ciclo.
 - Labels de tipo (`bug` / `new test`) são recomendadas; sem label o fluxo infere o tipo pelo título/corpo e usa fallback `newTest`.

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -3,13 +3,18 @@
 Este projeto ja possui automacao completa em GitHub Actions para:
 - CI de testes Playwright por estagios
 - Orquestracao de cards `Ready -> In progress -> In review`
-- Agendamento automatico de processamento de cards (cron no scheduler)
+- Agendamento automatico com loop por `workflow_run` + cron como backup
 - Execucao sem necessidade de interagir no terminal
 
 ## Workflows existentes
 - `.github/workflows/playwright.yml`
 - `.github/workflows/project-ready-scheduler.yml`
 - `.github/workflows/project-ready-orchestrator.yml`
+
+Modelo de execucao do scheduler:
+- `workflow_run` do orquestrador: mantem o loop automatico (com cooldown de 5 min)
+- `schedule`: backup de resiliencia
+- `push` em `main`: bootstrap automatico da esteira apos merge
 
 ## 1) Pre-requisitos
 - `gh` autenticado com acesso ao repositorio


### PR DESCRIPTION
## Context
`event=schedule` has not been firing reliably in this repository. The Ready automation flow itself is healthy, but cron-based triggering is unstable.

## Changes
- add `workflow_run` trigger in `project-ready-scheduler.yml` to keep a 5-minute loop after each orchestrator completion
- keep `schedule` as backup trigger
- add `push` on `main` as bootstrap trigger after merges
- add trigger context logging and cooldown (`sleep 300`) for loop cadence
- update README and setup docs with the new scheduler model

## Validation
- `npm run -s actions:verify`
- workflow wiring review in `.github/workflows/project-ready-scheduler.yml`
