### PR TITLE
fix: use project token for scheduler dispatch

### DIFF
--- a/.github/workflows/project-ready-scheduler.yml
+++ b/.github/workflows/project-ready-scheduler.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Dispatch Project Ready Orchestrator
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
           script: |
             const workflowId = 'project-ready-orchestrator.yml';
             await github.rest.actions.createWorkflowDispatch({

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -26,6 +26,8 @@ Modelo de execucao do scheduler:
 - `APP_USER_LOCKED_PASSWORD`
 - `APP_USER_INVALID_PASSWORD`
 
+`GH_PROJECT_TOKEN` tambem e usado pelo scheduler para disparar o orquestrador com permissao de encadear execucoes automaticas.
+
 Exemplo:
 ```bash
 gh secret set GH_PROJECT_TOKEN --repo BrunoZanotta/autonomous-testing-ui


### PR DESCRIPTION
## Context
The new `workflow_run` loop did not chain after orchestrator completion. Dispatches were still executed using `GITHUB_TOKEN`, which can suppress downstream workflow triggers.

## Changes
- configure scheduler dispatch step to use `secrets.GH_PROJECT_TOKEN`
- document that `GH_PROJECT_TOKEN` is also used for scheduler chaining

## Validation
- `npm run -s actions:verify`
