### PR TITLE
feat: move project card to done automatically on merge

### DIFF
--- a/.github/workflows/project-done-on-merge.yml
+++ b/.github/workflows/project-done-on-merge.yml
@@ -1,0 +1,65 @@
+name: Project Done On PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: project-done-on-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  move-linked-issue-cards-to-done:
+    name: Merge -> Done
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+      PROJECT_OWNER: ${{ github.repository_owner }}
+      PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER || '3' }}
+      PROJECT_REPO_FULL_NAME: ${{ github.repository }}
+      DONE_STATUS: Done
+
+    steps:
+      - name: Print trigger context
+        run: |
+          echo "event=${GITHUB_EVENT_NAME}"
+          echo "action=${{ github.event.action }}"
+          echo "pull_request=${{ github.event.pull_request.number }}"
+          echo "merged=${{ github.event.pull_request.merged }}"
+          date -u '+%Y-%m-%d %H:%M:%S UTC'
+
+      - name: Validate automation token
+        id: token
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "GH_PROJECT_TOKEN is not configured. Skipping Done sync."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.token.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: steps.token.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Move linked cards to Done
+        if: steps.token.outputs.enabled == 'true'
+        run: |
+          node ./scripts/git/project-pr-merge-to-done.mjs \
+            "${PROJECT_OWNER}" \
+            "${PROJECT_NUMBER}" \
+            "${PROJECT_REPO_FULL_NAME}" \
+            "${{ github.event.pull_request.number }}" \
+            "${DONE_STATUS}"

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -3,6 +3,7 @@
 Este projeto ja possui automacao completa em GitHub Actions para:
 - CI de testes Playwright por estagios
 - Orquestracao de cards `Ready -> In progress -> In review`
+- Sincronizacao automatica `PR merge -> Done` no Project
 - Agendamento automatico com loop por `workflow_run` + cron como backup
 - Execucao sem necessidade de interagir no terminal
 
@@ -10,6 +11,7 @@ Este projeto ja possui automacao completa em GitHub Actions para:
 - `.github/workflows/playwright.yml`
 - `.github/workflows/project-ready-scheduler.yml`
 - `.github/workflows/project-ready-orchestrator.yml`
+- `.github/workflows/project-done-on-merge.yml`
 
 Modelo de execucao do scheduler:
 - `workflow_run` do orquestrador: mantem o loop automatico (com cooldown de 5 min)
@@ -27,6 +29,7 @@ Modelo de execucao do scheduler:
 - `APP_USER_INVALID_PASSWORD`
 
 `GH_PROJECT_TOKEN` tambem e usado pelo scheduler para disparar o orquestrador com permissao de encadear execucoes automaticas.
+O mesmo token tambem e usado para mover card para `Done` no merge da PR.
 
 Exemplo:
 ```bash
@@ -86,5 +89,6 @@ gh workflow run project-ready-orchestrator.yml --repo BrunoZanotta/autonomous-te
 - Sem label de tipo, o fluxo infere o tipo pelo titulo/corpo e usa fallback `newTest`
 - Se o texto do card for generico (sem pista de inventory/cart), o gerador cria um teste padrao de carrinho com dois produtos
 - Priorizacao automatica: `bugfix` primeiro, depois `P0`, `P1`, `P2`
+- No merge da PR, o card vai para `Done` automaticamente quando a PR referencia a issue (`Refs #<numero>` ou `Closes #<numero>`)
 
 Se nao houver card elegivel, o workflow encerra sem erro.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "project:ready:item": "node ./scripts/git/project-ready-item.mjs",
     "project:ready:move": "node ./scripts/git/project-move-item.mjs",
     "project:ready:to-pr": "node ./scripts/git/project-ready-to-pr.mjs",
+    "project:pr:merge:done": "node ./scripts/git/project-pr-merge-to-done.mjs",
     "actions:verify": "node ./scripts/git/verify-actions-setup.mjs",
     "project:create-pr-flow": "node ./scripts/git/create-pr-flow.mjs",
     "project:ready:work": "node ./scripts/git/project-ready-work.mjs"

--- a/scripts/git/project-pr-merge-to-done.mjs
+++ b/scripts/git/project-pr-merge-to-done.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import { normalizeStatus, safeJsonParse, run } from '../lib/cli.mjs';
+import {
+  describeStatusOptions,
+  ensureGhAuthenticated,
+  findStatusField,
+  getProjectNodeFromResponse,
+  ghGraphql,
+  matchStatusOption,
+  MOVE_ITEM_MUTATION,
+  PROJECT_READY_QUERY,
+} from './lib/github-project.mjs';
+
+function usage() {
+  console.error(
+    'usage: node scripts/git/project-pr-merge-to-done.mjs <owner> <project_number> <repo_full_name> <pr_number> [done_status]',
+  );
+}
+
+const owner = process.argv[2] ?? '';
+const projectNumberRaw = process.argv[3] ?? '';
+const repoFullName = process.argv[4] ?? '';
+const prNumberRaw = process.argv[5] ?? '';
+const doneStatus = process.argv[6] ?? 'Done';
+
+if (!owner || !projectNumberRaw || !repoFullName || !prNumberRaw) {
+  usage();
+  process.exit(1);
+}
+
+const projectNumber = Number.parseInt(projectNumberRaw, 10);
+if (!Number.isInteger(projectNumber) || projectNumber <= 0) {
+  console.error(`error: invalid project number '${projectNumberRaw}'`);
+  process.exit(1);
+}
+
+const prNumber = Number.parseInt(prNumberRaw, 10);
+if (!Number.isInteger(prNumber) || prNumber <= 0) {
+  console.error(`error: invalid pull request number '${prNumberRaw}'`);
+  process.exit(1);
+}
+
+const repoMatch = repoFullName.match(/^([^/]+)\/([^/]+)$/);
+if (!repoMatch) {
+  console.error(`error: invalid repo_full_name '${repoFullName}'. expected owner/repo`);
+  process.exit(1);
+}
+
+const repoName = repoMatch[2];
+
+function readPullRequest(repo, number) {
+  const response = run('gh', ['api', `repos/${repo}/pulls/${number}`], { allowFailure: true });
+  if (!response.ok) {
+    const details = response.stderr || response.stdout || 'failed to read pull request';
+    throw new Error(details);
+  }
+
+  const parsed = safeJsonParse(response.stdout);
+  if (!parsed) {
+    throw new Error('error: invalid pull request JSON response');
+  }
+
+  return parsed;
+}
+
+function readClosingIssueNumbersFromGraphql(prNum) {
+  const query = `
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      closingIssuesReferences(first:20) {
+        nodes {
+          number
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }
+}`;
+
+  const response = ghGraphql(
+    query,
+    {
+      owner,
+      repo: repoName,
+      number: prNum,
+    },
+    { retries: 1 },
+  );
+
+  const nodes = response?.data?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? [];
+  return nodes
+    .filter((node) => String(node?.repository?.nameWithOwner ?? '') === repoFullName)
+    .map((node) => Number.parseInt(String(node?.number ?? ''), 10))
+    .filter((value) => Number.isInteger(value) && value > 0);
+}
+
+function parseIssueNumbersFromText(text) {
+  const values = new Set();
+  const source = String(text ?? '');
+  const keywordRegex = /(?:refs?|related to|close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+
+  let match = keywordRegex.exec(source);
+  while (match) {
+    const value = Number.parseInt(match[1], 10);
+    if (Number.isInteger(value) && value > 0) {
+      values.add(value);
+    }
+    match = keywordRegex.exec(source);
+  }
+
+  return values;
+}
+
+function getItemStatus(item) {
+  const values = Array.isArray(item?.fieldValues?.nodes) ? item.fieldValues.nodes : [];
+  const statusValue = values.find((node) => normalizeStatus(node?.field?.name) === 'status');
+  return String(statusValue?.name ?? '');
+}
+
+try {
+  ensureGhAuthenticated({ requireProjectWrite: true });
+
+  const pr = readPullRequest(repoFullName, prNumber);
+  if (!pr?.merged_at) {
+    console.log(
+      JSON.stringify({
+        status: 'PULL_REQUEST_NOT_MERGED',
+        pull_request: prNumber,
+      }),
+    );
+    process.exit(0);
+  }
+
+  const issueNumbers = new Set();
+  for (const value of readClosingIssueNumbersFromGraphql(prNumber)) {
+    issueNumbers.add(value);
+  }
+  for (const value of parseIssueNumbersFromText(pr.body ?? '')) {
+    issueNumbers.add(value);
+  }
+
+  const linkedIssues = Array.from(issueNumbers).sort((a, b) => a - b);
+  if (linkedIssues.length === 0) {
+    console.log(
+      JSON.stringify({
+        status: 'NO_LINKED_ISSUES',
+        pull_request: prNumber,
+        repo: repoFullName,
+      }),
+    );
+    process.exit(0);
+  }
+
+  const projectResponse = ghGraphql(PROJECT_READY_QUERY, {
+    owner,
+    number: projectNumber,
+  });
+  const project = getProjectNodeFromResponse(projectResponse, owner, projectNumber);
+  const statusField = findStatusField(project);
+  const doneOption = matchStatusOption(statusField, doneStatus);
+
+  if (!doneOption) {
+    const options = describeStatusOptions(statusField);
+    throw new Error(`error: target status '${doneStatus}' not found. Available: ${options.join(', ')}`);
+  }
+
+  const items = Array.isArray(project?.items?.nodes) ? project.items.nodes : [];
+  const moved = [];
+  const alreadyDone = [];
+  const notFound = [];
+
+  for (const issueNumber of linkedIssues) {
+    const item = items.find(
+      (node) =>
+        node?.content?.__typename === 'Issue' &&
+        Number.parseInt(String(node?.content?.number ?? ''), 10) === issueNumber &&
+        String(node?.content?.repository?.nameWithOwner ?? '') === repoFullName,
+    );
+
+    if (!item) {
+      notFound.push(issueNumber);
+      continue;
+    }
+
+    const currentStatus = getItemStatus(item);
+    if (normalizeStatus(currentStatus) === normalizeStatus(doneStatus)) {
+      alreadyDone.push(issueNumber);
+      continue;
+    }
+
+    ghGraphql(MOVE_ITEM_MUTATION, {
+      project: String(project.id),
+      item: String(item.id),
+      field: String(statusField.id),
+      option: String(doneOption.id),
+    });
+
+    moved.push(issueNumber);
+  }
+
+  console.log(
+    JSON.stringify({
+      status: 'DONE_SYNC_COMPLETED',
+      pull_request: prNumber,
+      repo: repoFullName,
+      linked_issues: linkedIssues,
+      moved_to_done: moved,
+      already_done: alreadyDone,
+      not_found_in_project: notFound,
+      target_status: doneStatus,
+    }),
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/git/verify-actions-setup.mjs
+++ b/scripts/git/verify-actions-setup.mjs
@@ -20,6 +20,7 @@ const REQUIRED_WORKFLOWS = [
   '.github/workflows/playwright.yml',
   '.github/workflows/project-ready-orchestrator.yml',
   '.github/workflows/project-ready-scheduler.yml',
+  '.github/workflows/project-done-on-merge.yml',
 ];
 
 function parseRepoFromOrigin() {


### PR DESCRIPTION
## Context
After merging a PR, the project card only moved to `Done` when the issue was manually closed.

## Changes
- add workflow `.github/workflows/project-done-on-merge.yml` triggered on `pull_request.closed` with `merged=true`
- add script `scripts/git/project-pr-merge-to-done.mjs` to resolve linked issue numbers from PR and move matching project items to `Done`
- keep behavior safe: if no linked issue is found, workflow exits without failure
- update setup verifier to require the new workflow
- update docs and npm scripts

## Validation
- `node --check scripts/git/project-pr-merge-to-done.mjs`
- `node ./scripts/git/project-pr-merge-to-done.mjs BrunoZanotta 3 BrunoZanotta/autonomous-testing-ui 20 Done`
- `npm run -s actions:verify`
