### PR TITLE
fix: [AUTO FLOW] Refactor test names to English and remove wrong generated test

### DIFF
--- a/tests/cart/cart-006-auto-flow-refactor-test-names-to-english-and-remove-wrong-generated-test.spec.ts
+++ b/tests/cart/cart-006-auto-flow-refactor-test-names-to-english-and-remove-wrong-generated-test.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '../../fixtures/app.fixture';
+
+test.describe('Shopping Cart Tests', { tag: '@cart' }, () => {
+  test('Cart Two Products Validation', { tag: '@regression' }, async ({ authenticatedPage: _authenticatedPage, inventoryPage, cartPage, checkoutPage }) => {
+    await inventoryPage.assertOnInventoryPage();
+    await inventoryPage.assertProductCardDetailsFor('onesie');
+    await inventoryPage.assertProductCardDetailsFor('bikeLight');
+
+    await inventoryPage.addProductToCartByKey('onesie');
+    await inventoryPage.addProductToCartByKey('bikeLight');
+    await inventoryPage.assertCartBadgeCount(2);
+
+    await inventoryPage.goToCart();
+    await cartPage.assertOnCartPage();
+    await cartPage.assertCartItemCount(2);
+    await cartPage.assertProductDetailsInCartByKey('onesie');
+    await cartPage.assertProductDetailsInCartByKey('bikeLight');
+
+    await cartPage.proceedToCheckout();
+    await checkoutPage.assertOnCheckoutInfoPage();
+    await checkoutPage.fillCheckoutInformationFromProfile('valid');
+    await checkoutPage.clickContinue();
+
+    await checkoutPage.assertOnCheckoutOverviewPage();
+    await checkoutPage.assertProductInOverviewByKey('onesie');
+    await checkoutPage.assertProductInOverviewByKey('bikeLight');
+    await checkoutPage.assertSubtotalEqualsProductSum(['onesie', 'bikeLight']);
+    await checkoutPage.assertTotalEqualsSubtotalPlusTax();
+  });
+});


### PR DESCRIPTION
## Summary
- Automated Ready flow for issue: [AUTO FLOW] Refactor test names to English and remove wrong generated test
- Branch: `bugfix/auto-flow-refactor-test-names-to-english-a`
- Test generated: `tests/cart/cart-006-auto-flow-refactor-test-names-to-english-and-remove-wrong-generated-test.spec.ts`

## Validation
- Governance gate executed
- Playwright test discovery attempted

Refs #28
