### PR TITLE
fix: make ready work engine intent-aware

### DIFF
--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -87,6 +87,9 @@ gh workflow run project-ready-orchestrator.yml --repo BrunoZanotta/autonomous-te
 - Card precisa estar em `Ready`
 - Label de tipo recomendada: `bug` ou `new test`
 - Sem label de tipo, o fluxo infere o tipo pelo titulo/corpo e usa fallback `newTest`
+- A execucao do trabalho agora detecta intencao no texto do card: `create`, `refactor`, `delete`
+- Quando o card pedir refactor/delete, o fluxo nao cria novo teste por padrao
+- Para exclusao, informe caminho explicito do arquivo (`tests/...spec.ts`) no card
 - Se o texto do card for generico (sem pista de inventory/cart), o gerador cria um teste padrao de carrinho com dois produtos
 - Priorizacao automatica: `bugfix` primeiro, depois `P0`, `P1`, `P2`
 - No merge da PR, o card vai para `Done` automaticamente quando a PR referencia a issue (`Refs #<numero>` ou `Closes #<numero>`)


### PR DESCRIPTION
## Context
The automation was always creating a new test, even for cards that requested refactor/delete operations.

## Changes
- update `project-ready-work.mjs` to detect intent from card text (`create`, `refactor`, `delete`)
- when card requests refactor/delete, avoid implicit test creation
- require explicit file path for delete operations
- implement automatic refactor path scan for Portuguese test names/content when refactor is requested
- improve dry-run/action summary output
- document the new behavior in setup docs

## Validation
- `node --check scripts/git/project-ready-work.mjs`
- `PROJECT_CARD_WORK_TYPE=bugfix DRY_RUN=1 RUN_TARGETED_TESTS=0 node ./scripts/git/project-ready-work.mjs` with refactor+delete card text
- `npm run -s actions:verify`
