### PR TITLE
fix: make project-ready worker handle step/refactor/delete intents

### DIFF
--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -90,6 +90,8 @@ gh workflow run project-ready-orchestrator.yml --repo BrunoZanotta/autonomous-te
 - A execucao do trabalho agora detecta intencao no texto do card: `create`, `refactor`, `delete`
 - Quando o card pedir refactor/delete, o fluxo nao cria novo teste por padrao
 - Para exclusao, informe caminho explicito do arquivo (`tests/...spec.ts`) no card
+- Refactor com `test.step` no texto do card aplica instrumentacao de steps nos testes e atualiza regra nos agentes de criacao/refatoracao
+- Delete e idempotente: se arquivo ja nao existir, o fluxo registra `Missing` e segue sem falhar
 - Se o texto do card for generico (sem pista de inventory/cart), o gerador cria um teste padrao de carrinho com dois produtos
 - Priorizacao automatica: `bugfix` primeiro, depois `P0`, `P1`, `P2`
 - No merge da PR, o card vai para `Done` automaticamente quando a PR referencia a issue (`Refs #<numero>` ou `Closes #<numero>`)


### PR DESCRIPTION
## Context
Card-driven automation was still failing in refactor scenarios:
- it could create a new test when the request was refactor/delete
- it failed when delete targets were already absent
- it couldn't process cards requesting `test.step` instrumentation and agent-rule updates

## Changes
- intent parser now sanitizes file paths before classifying actions
- explicit intent facets: `refactor_names`, `refactor_steps`, `update_agent_rule`
- add `test.step` instrumentation flow for test files when step-refactor is requested
- add agent rule auto-update for:
  - `.github/agents/playwright/qa-generator.agent.md`
  - `.github/agents/playwright/qa-test-refactorer.agent.md`
- make delete flow idempotent (missing files become warning, not failure, for delete-only cards)
- docs updated with new behavior

## Validation
- `node --check scripts/git/project-ready-work.mjs`
- dry-run scenarios:
  - refactor+step+agent-rule card
  - delete-only card
  - create-only card
- `npm run -s actions:verify`
